### PR TITLE
Search for user DN when BIND_AS_AUTHENTICATING_USER=True

### DIFF
--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -365,6 +365,10 @@ class _LDAPUser(object):
             sticky = self.settings.BIND_AS_AUTHENTICATING_USER
 
             self._bind_as(self.dn, password, sticky=sticky)
+            
+            if sticky and self.settings.AUTH_LDAP_USER_SEARCH:
+                self._search_for_user_dn()
+                
         except self.ldap.INVALID_CREDENTIALS:
             raise self.AuthenticationFailed("User DN/password rejected by LDAP server.")
 
@@ -472,7 +476,6 @@ class _LDAPUser(object):
 
         if should_populate:
             logger.debug("Populating Django user %s", username)
-            self._search_for_user_dn()
             self._populate_user()
             save_user = True
 

--- a/django_auth_ldap/backend.py
+++ b/django_auth_ldap/backend.py
@@ -472,6 +472,7 @@ class _LDAPUser(object):
 
         if should_populate:
             logger.debug("Populating Django user %s", username)
+            self._search_for_user_dn()
             self._populate_user()
             save_user = True
 


### PR DESCRIPTION
I needed to do this to get user attrs when logging in with an account name. It's a simple fix but I'm not sure it's the best way to go about it. Would like to open up the discussion and possibly implement.

BIND_AS_AUTHENTICATING_USER = True
AUTH_LDAP_USER_DN_TEMPLATE = "%(user)s@your.domain"
AUTH_LDAP_USER_SEARCH = LDAPSearch(
    "ou=USERS,dc=your,dc=domain",
    ldap.SCOPE_SUBTREE,
    "(sAMAccountName=%(user)s)"
)
